### PR TITLE
adding a wait for sdm to start

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,3 +38,6 @@ runs:
     - name: Update StrongDM config
       run: sdm k8s update-config
       shell: bash
+    - name: Wait for auto connect
+      run: sleep 5
+      shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -22,10 +22,18 @@ runs:
       run: unzip sdm.zip
       shell: bash
     - name: Install StrongDM
-      run: sudo ./sdm install --admin-token=${{ inputs.sdm-admin-token }}
+      run: sudo ./sdm install --nologin
       shell: bash
     - name: Login to StrongDM
       run: sdm login --admin-token=${{ inputs.sdm-admin-token }}
+      shell: bash
+    - name: Wait for StrongDM to start
+      run: |
+        until sdm status &> /dev/null;
+        do
+          sleep 1
+          echo "waiting for SDM to start"
+        done
       shell: bash
     - name: Update StrongDM config
       run: sdm k8s update-config

--- a/action.yaml
+++ b/action.yaml
@@ -39,5 +39,10 @@ runs:
       run: sdm k8s update-config
       shell: bash
     - name: Wait for auto connect
-      run: sleep 5
+      run: |
+        while [ $( kubectl version -o json | jq 'has("serverVersion")' ) = false ];
+        do
+          sleep 1
+          echo "waiting for connection"
+        done
       shell: bash


### PR DESCRIPTION
Tested this process and it works. 
This waits until sdm status returns successful. Similar to the script here: https://www.strongdm.com/docs/admin/deployment/docker/client/#entrypoint-script